### PR TITLE
HID: añadidas las funciones de teclado matricial+ENTER+BACKSPACE

### DIFF
--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/Makefile
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2016, Pablo Ridolfi
+# Copyright 2016, Eric Pernia
+# All rights reserved.
+#
+# This file is part of Workspace.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# application name
+PROJECT_NAME := $(notdir $(PROJECT))
+
+# Modules needed by the application
+PROJECT_MODULES := modules/$(TARGET)/sapi \
+                   modules/$(TARGET)/base \
+                   modules/$(TARGET)/board \
+                   modules/$(TARGET)/chip
+
+# source files folder
+PROJECT_SRC_FOLDERS := $(PROJECT)/src
+
+# header files folder
+PROJECT_INC_FOLDERS := $(PROJECT)/inc
+
+# source files
+PROJECT_C_FILES := $(wildcard $(PROJECT)/src/*.c)
+PROJECT_ASM_FILES := $(wildcard $(PROJECT)/src/*.S)

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/Readme.md
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/Readme.md
@@ -1,0 +1,8 @@
+Recordar compilar con "make" desde dentro esta misma carpeta, no usan nada del
+CIAA-Firmware.
+
+Este ejemplo convierte a la EDU-CIAA en un teclado USB.
+
+Con las teclas de la EDU-CIAA-NXP TEC1 a TEC3 escribe "c", "i", "a" 
+respectivamente. Con TEC4 "Enter". 
+El LEDB indica el estado del "Num Lock".

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/app_usbd_cfg.h
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/app_usbd_cfg.h
@@ -1,0 +1,113 @@
+/*
+ * @brief Configuration file needed for USB ROM stack based applications.
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2013
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+#include "lpc_types.h"
+#include "error.h"
+#include "usbd_rom_api.h"
+
+#ifndef __APP_USB_CFG_H_
+#define __APP_USB_CFG_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** @ingroup EXAMPLES_USBDROM_18XX43XX_KEYBOARD
+ * @{
+ */
+
+/* Comment below and uncomment USE_USB1 to enable USB1 */
+#define USE_USB0
+/* #define USE_USB1 */
+
+/* Manifest constants used by USBD ROM stack. These values SHOULD NOT BE CHANGED
+   for advance features which require usage of USB_CORE_CTRL_T structure.
+   Since these are the values used for compiling USB stack.
+ */
+#define USB_MAX_IF_NUM          8		/*!< Max interface number used for building USBD ROM. DON'T CHANGE. */
+#define USB_MAX_EP_NUM          6		/*!< Max number of EP used for building USBD ROM. DON'T CHANGE. */
+#define USB_MAX_PACKET0         64		/*!< Max EP0 packet size used for building USBD ROM. DON'T CHANGE. */
+#define USB_FS_MAX_BULK_PACKET  64		/*!< MAXP for FS bulk EPs used for building USBD ROM. DON'T CHANGE. */
+#define USB_HS_MAX_BULK_PACKET  512		/*!< MAXP for HS bulk EPs used for building USBD ROM. DON'T CHANGE. */
+#define USB_DFU_XFER_SIZE       2048	/*!< Max DFU transfer size used for building USBD ROM. DON'T CHANGE. */
+
+/* Manifest constants to select appropriate USB instance */
+#ifdef USE_USB0
+#define LPC_USB_BASE            LPC_USB0_BASE
+#define LPC_USB                 LPC_USB0
+#define LPC_USB_IRQ             USB0_IRQn
+#define USB_IRQHandler          USB0_IRQHandler
+#define USB_init_pin_clk        Chip_USB0_Init
+#else
+#undef USB_IRQHandler
+#define LPC_USB_BASE            LPC_USB1_BASE
+#define LPC_USB                 LPC_USB1
+#define LPC_USB_IRQ             USB1_IRQn
+#define USB_IRQHandler          USB1_IRQHandler
+#define USB_init_pin_clk        Chip_USB1_Init
+#endif
+
+/* HID In/Out Endpoint Address */
+#define HID_EP_IN       0x81
+#define HID_EP_OUT      0x01
+
+/* On LPC18xx/43xx the USB controller requires endpoint queue heads to start on
+   a 4KB aligned memory. Hence the mem_base value passed to USB stack init should
+   be 4KB aligned. The following manifest constants are used to define this memory.
+ */
+#define USB_STACK_MEM_BASE      0x20000000
+#define USB_STACK_MEM_SIZE      0x00002000
+
+/* USB descriptor arrays defined *_desc.c file */
+extern const uint8_t USB_DeviceDescriptor[];
+extern uint8_t USB_HsConfigDescriptor[];
+extern uint8_t USB_FsConfigDescriptor[];
+extern const uint8_t USB_StringDescriptor[];
+extern const uint8_t USB_DeviceQualifier[];
+
+/**
+ * @brief	Find the address of interface descriptor for given class type.
+ * @param	pDesc		: Pointer to configuration descriptor in which the desired class
+ *			interface descriptor to be found.
+ * @param	intfClass	: Interface class type to be searched.
+ * @return	If found returns the address of requested interface else returns NULL.
+ */
+extern USB_INTERFACE_DESCRIPTOR *find_IntfDesc(const uint8_t *pDesc, uint32_t intfClass);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APP_USB_CFG_H_ */

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/hid_keyboard.h
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/hid_keyboard.h
@@ -1,0 +1,79 @@
+/*
+ * @brief This file contains USB HID Keyboard example using USB ROM Drivers.
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2013
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+
+#ifndef __HID_KEYBOARD_H_
+#define __HID_KEYBOARD_H_
+
+#include "app_usbd_cfg.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** @ingroup EXAMPLES_USBDROM_18XX43XX_KEYBOARD
+ * @{
+ */
+
+#define KEYBOARD_REPORT_SIZE                        8
+
+#define HID_KEYBOARD_CLEAR_REPORT(x)                memset(x, 0, 8);
+#define HID_KEYBOARD_REPORT_SET_KEY_PRESS(x, val)   x[2] = (uint8_t) val;
+
+/**
+ * @brief	HID keyboard interface init routine.
+ * @param	hUsb		: Handle to USB device stack
+ * @param	pIntfDesc	: Pointer to HID interface descriptor
+ * @param	mem_base	: Pointer to memory address which can be used by HID driver
+ * @param	mem_size	: Size of the memory passed
+ * @return	On success returns LPC_OK. Params mem_base and mem_size are updated
+ *			to point to new base and available size.
+ */
+extern ErrorCode_t Keyboard_init(USBD_HANDLE_T hUsb,
+								 USB_INTERFACE_DESCRIPTOR *pIntfDesc,
+								 uint32_t *mem_base,
+								 uint32_t *mem_size);
+
+/**
+ * @brief	Keyboard tasks.
+ * @return	On success returns LPC_OK.
+ */
+extern void Keyboard_Tasks(void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HID_KEYBOARD_H_ */

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/keypad4x4.h
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/inc/keypad4x4.h
@@ -1,0 +1,2 @@
+void configurarTecladoMatricial( void );
+uint16_t leerTecladoMatricial( void );

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/hid_desc.c
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/hid_desc.c
@@ -1,0 +1,292 @@
+/*
+ * @brief This file contains USB HID Keyboard example using USB ROM Drivers.
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2013
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+
+#include "app_usbd_cfg.h"
+
+/*****************************************************************************
+ * Private types/enumerations/variables
+ ****************************************************************************/
+
+/*****************************************************************************
+ * Public types/enumerations/variables
+ ****************************************************************************/
+
+/**
+ * HID Keyboard Report Descriptor
+ */
+const uint8_t Keyboard_ReportDescriptor[] = {
+   HID_UsagePage(HID_USAGE_PAGE_GENERIC),
+   HID_Usage(HID_USAGE_GENERIC_KEYBOARD),
+   HID_Collection(HID_Application),
+   HID_UsagePage(HID_USAGE_PAGE_KEYBOARD),
+   HID_UsageMin(224),
+   HID_UsageMax(231),
+   HID_LogicalMin(0),
+   HID_LogicalMax(1),
+   HID_ReportSize(1),
+   HID_ReportCount(8),
+   HID_Input(HID_Data | HID_Variable | HID_Absolute),
+   HID_ReportCount(1),
+   HID_ReportSize(8),
+   HID_Input(HID_Constant),
+   HID_ReportCount(5),
+   HID_ReportSize(1),
+   HID_UsagePage(HID_USAGE_PAGE_LED),
+   HID_UsageMin(1),
+   HID_UsageMax(5),
+   HID_Output(HID_Data | HID_Variable | HID_Absolute),
+   HID_ReportCount(1),
+   HID_ReportSize(3),
+   HID_Output(HID_Constant),
+   HID_ReportCount(6),
+   HID_ReportSize(8),
+   HID_LogicalMin(0),
+   HID_LogicalMax(101),
+   HID_UsagePage(HID_USAGE_PAGE_KEYBOARD),
+   HID_UsageMin(0),
+   HID_UsageMax(101),
+   HID_Input(HID_Array),
+   HID_EndCollection,
+};
+const uint16_t Keyboard_ReportDescSize = sizeof(Keyboard_ReportDescriptor);
+
+/**
+ * USB Standard Device Descriptor
+ */
+ALIGNED(4) const uint8_t USB_DeviceDescriptor[] = {
+   USB_DEVICE_DESC_SIZE,                       /* bLength */
+   USB_DEVICE_DESCRIPTOR_TYPE,                 /* bDescriptorType */
+   WBVAL(0x0200),                              /* bcdUSB: 2.00 */
+   0x00,                                       /* bDeviceClass */
+   0x00,                                       /* bDeviceSubClass */
+   0x00,                                       /* bDeviceProtocol */
+   USB_MAX_PACKET0,                            /* bMaxPacketSize0 */
+   WBVAL(0x1FC9),                              /* idVendor */
+   WBVAL(0x0086),                              /* idProduct */
+   WBVAL(0x0100),                              /* bcdDevice */
+   0x01,                                       /* iManufacturer */
+   0x02,                                       /* iProduct */
+   0x03,                                       /* iSerialNumber */
+   0x01                                        /* bNumConfigurations */
+};
+
+ALIGNED(4) const uint8_t USB_DeviceQualifier[] = {
+   USB_DEVICE_QUALI_SIZE,                      /* bLength */
+   USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE,       /* bDescriptorType */
+   WBVAL(0x0200),                              /* bcdUSB: 2.00 */
+   0x00,                                       /* bDeviceClass */
+   0x00,                                       /* bDeviceSubClass */
+   0x00,                                       /* bDeviceProtocol */
+   USB_MAX_PACKET0,                            /* bMaxPacketSize0 */
+   0x01,                                       /* bNumOtherSpeedConfigurations */
+   0x00                                        /* bReserved */
+};
+
+/**
+ * USB HSConfiguration Descriptor
+ * All Descriptors (Configuration, Interface, Endpoint, Class, Vendor)
+ */
+ALIGNED(4) uint8_t USB_HsConfigDescriptor[] = {
+   /* Configuration 1 */
+   USB_CONFIGURATION_DESC_SIZE,                /* bLength */
+   USB_CONFIGURATION_DESCRIPTOR_TYPE,          /* bDescriptorType */
+   WBVAL(                                      /* wTotalLength */
+      USB_CONFIGURATION_DESC_SIZE +
+      USB_INTERFACE_DESC_SIZE     +
+      HID_DESC_SIZE               +
+      USB_ENDPOINT_DESC_SIZE
+      ),
+   0x01,                                       /* bNumInterfaces */
+   0x01,                                       /* bConfigurationValue */
+   0x00,                                       /* iConfiguration */
+   USB_CONFIG_SELF_POWERED,                    /* bmAttributes */
+   USB_CONFIG_POWER_MA(2),                     /* bMaxPower */
+
+   /* Interface 0, Alternate Setting 0, HID Class */
+   USB_INTERFACE_DESC_SIZE,                    /* bLength */
+   USB_INTERFACE_DESCRIPTOR_TYPE,              /* bDescriptorType */
+   0x00,                                       /* bInterfaceNumber */
+   0x00,                                       /* bAlternateSetting */
+   0x01,                                       /* bNumEndpoints */
+   USB_DEVICE_CLASS_HUMAN_INTERFACE,           /* bInterfaceClass */
+   HID_SUBCLASS_BOOT,                          /* bInterfaceSubClass */
+   HID_PROTOCOL_KEYBOARD,                      /* bInterfaceProtocol */
+   0x04,                                       /* iInterface */
+   /* HID Class Descriptor */
+   /* HID_DESC_OFFSET = 0x0012 */
+   HID_DESC_SIZE,                              /* bLength */
+   HID_HID_DESCRIPTOR_TYPE,                    /* bDescriptorType */
+   WBVAL(0x0111),                              /* bcdHID : 1.11*/
+   0x00,                                       /* bCountryCode */
+   0x01,                                       /* bNumDescriptors */
+   HID_REPORT_DESCRIPTOR_TYPE,                 /* bDescriptorType */
+   WBVAL(sizeof(Keyboard_ReportDescriptor)),   /* wDescriptorLength */
+   /* Endpoint, HID Interrupt In */
+   USB_ENDPOINT_DESC_SIZE,                     /* bLength */
+   USB_ENDPOINT_DESCRIPTOR_TYPE,               /* bDescriptorType */
+   HID_EP_IN,                                  /* bEndpointAddress */
+   USB_ENDPOINT_TYPE_INTERRUPT,                /* bmAttributes */
+   WBVAL(0x0008),                              /* wMaxPacketSize */
+   0x08,                                       /* bInterval */
+   /* Terminator */
+   0                                           /* bLength */
+};
+
+/**
+ * USB FSConfiguration Descriptor
+ * All Descriptors (Configuration, Interface, Endpoint, Class, Vendor)
+ */
+ALIGNED(4) uint8_t USB_FsConfigDescriptor[] = {
+   /* Configuration 1 */
+   USB_CONFIGURATION_DESC_SIZE,                /* bLength */
+   USB_CONFIGURATION_DESCRIPTOR_TYPE,          /* bDescriptorType */
+   WBVAL(                                      /* wTotalLength */
+      USB_CONFIGURATION_DESC_SIZE   +
+      USB_INTERFACE_DESC_SIZE     +
+      HID_DESC_SIZE               +
+      USB_ENDPOINT_DESC_SIZE
+      ),
+   0x01,                                       /* bNumInterfaces */
+   0x01,                                       /* bConfigurationValue */
+   0x00,                                       /* iConfiguration */
+   USB_CONFIG_SELF_POWERED,                    /* bmAttributes */
+   USB_CONFIG_POWER_MA(2),                     /* bMaxPower */
+
+   /* Interface 0, Alternate Setting 0, HID Class */
+   USB_INTERFACE_DESC_SIZE,                    /* bLength */
+   USB_INTERFACE_DESCRIPTOR_TYPE,              /* bDescriptorType */
+   0x00,                                       /* bInterfaceNumber */
+   0x00,                                       /* bAlternateSetting */
+   0x01,                                       /* bNumEndpoints */
+   USB_DEVICE_CLASS_HUMAN_INTERFACE,           /* bInterfaceClass */
+   HID_SUBCLASS_BOOT,                          /* bInterfaceSubClass */
+   HID_PROTOCOL_KEYBOARD,                      /* bInterfaceProtocol */
+   0x04,                                       /* iInterface */
+   /* HID Class Descriptor */
+   /* HID_DESC_OFFSET = 0x0012 */
+   HID_DESC_SIZE,                              /* bLength */
+   HID_HID_DESCRIPTOR_TYPE,                    /* bDescriptorType */
+   WBVAL(0x0111),                              /* bcdHID : 1.11*/
+   0x00,                                       /* bCountryCode */
+   0x01,                                       /* bNumDescriptors */
+   HID_REPORT_DESCRIPTOR_TYPE,                 /* bDescriptorType */
+   WBVAL(sizeof(Keyboard_ReportDescriptor)),   /* wDescriptorLength */
+   /* Endpoint, HID Interrupt In */
+   USB_ENDPOINT_DESC_SIZE,                     /* bLength */
+   USB_ENDPOINT_DESCRIPTOR_TYPE,               /* bDescriptorType */
+   HID_EP_IN,                                  /* bEndpointAddress */
+   USB_ENDPOINT_TYPE_INTERRUPT,                /* bmAttributes */
+   WBVAL(0x0008),                              /* wMaxPacketSize */
+   0x0A,                                       /* bInterval */
+   /* Terminator */
+   0                                           /* bLength */
+};
+
+/**
+ * USB String Descriptor (optional)
+ */
+const uint8_t USB_StringDescriptor[] = {
+   /* Index 0x00: LANGID Codes */
+   0x04,							      /* bLength */
+   USB_STRING_DESCRIPTOR_TYPE,   /* bDescriptorType */
+   WBVAL(0x0409),					   /* wLANGID  0x0409 = US English*/
+   /* Index 0x01: Manufacturer */
+   (18 * 2 + 2),					   /* bLength (18 Char + Type + length) */
+   USB_STRING_DESCRIPTOR_TYPE,   /* bDescriptorType */
+   'N', 0,
+   'X', 0,
+   'P', 0,
+   ' ', 0,
+   'S', 0,
+   'e', 0,
+   'm', 0,
+   'i', 0,
+   'c', 0,
+   'o', 0,
+   'n', 0,
+   'd', 0,
+   'u', 0,
+   'c', 0,
+   't', 0,
+   'o', 0,
+   'r', 0,
+   's', 0,
+   /* Index 0x02: Product */
+   (16 * 2 + 2),					   /* bLength (16 Char + Type + length) */
+   USB_STRING_DESCRIPTOR_TYPE,   /* bDescriptorType */
+   'L', 0,
+   'P', 0,
+   'C', 0,
+   '1', 0,
+   '8', 0,
+   'x', 0,
+   'x', 0,
+   ' ', 0,
+   'K', 0,
+   'E', 0,
+   'Y', 0,
+   'B', 0,
+   'O', 0,
+   'A', 0,
+   'R', 0,
+   'D', 0,
+   /* Index 0x03: Serial Number */
+   (13 * 2 + 2),					   /* bLength (13 Char + Type + length) */
+   USB_STRING_DESCRIPTOR_TYPE,   /* bDescriptorType */
+   'A', 0,
+   'B', 0,
+   'C', 0,
+   'D', 0,
+   '1', 0,
+   '2', 0,
+   '3', 0,
+   '4', 0,
+   '5', 0,
+   '6', 0,
+   '7', 0,
+   '8', 0,
+   '9', 0,
+   /* Index 0x04: Interface 0, Alternate Setting 0 */
+   (12 * 2 + 2),					   /* bLength (12 Char + Type + length) */
+   USB_STRING_DESCRIPTOR_TYPE,   /* bDescriptorType */
+   'H', 0,
+   'I', 0,
+   'D', 0,
+   ' ', 0,
+   'K', 0,
+   'E', 0,
+   'Y', 0,
+   'B', 0,
+   'O', 0,
+   'A', 0,
+   'R', 0,
+   'D', 0,
+};

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/hid_keyboard.c
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/hid_keyboard.c
@@ -1,0 +1,271 @@
+/*
+ * @brief This file contains USB HID Keyboard example using USB ROM Drivers.
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2013
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+
+#include "sapi.h"
+#include <stdint.h>
+#include <string.h>
+#include "keypad4x4.h"
+#include "usbd_rom_api.h"
+#include "hid_keyboard.h"
+uint8_t  state = 0;
+uint16_t tecl_pres = 0;
+// Añadidas las teclas del teclado matricial - state = 0
+// En este modo el led verde está apagado
+uint16_t keypadKeys[16] = {
+                               0x1E, 0x1F, 0x20, 0x04,
+                               0x21, 0x22, 0x23, 0x05,
+                               0x24, 0x25, 0x26, 0x06,
+                               0x55, 0x27, 0xCC, 0x07
+                          };
+//Añadidas las teclas "ENTER" y "BACKSPACE"
+//En este modo el led verde está encendido para indicar state = 1
+uint16_t keypadKeysVol[2] = {
+							   0x28, 0x2A
+};
+
+/*****************************************************************************
+ * Private types/enumerations/variables
+ ****************************************************************************/
+
+/**
+ * @brief Structure to hold Keyboard data
+ */
+typedef struct {
+	USBD_HANDLE_T hUsb;	/*!< Handle to USB stack. */
+	uint8_t report[KEYBOARD_REPORT_SIZE];	/*!< Last report data  */
+	uint8_t tx_busy;	/*!< Flag indicating whether a report is pending in endpoint queue. */
+} Keyboard_Ctrl_T;
+
+/** Singleton instance of Keyboard control */
+static Keyboard_Ctrl_T g_keyBoard;
+
+/*****************************************************************************
+ * Public types/enumerations/variables
+ ****************************************************************************/
+
+extern const uint8_t Keyboard_ReportDescriptor[];
+extern const uint16_t Keyboard_ReportDescSize;
+
+/*****************************************************************************
+ * Private functions
+ ****************************************************************************/
+
+/* Routine to update keyboard state */
+static void Keyboard_UpdateReport(void){
+
+   HID_KEYBOARD_CLEAR_REPORT(&g_keyBoard.report[0]);
+ // Selección del state, para definir la función del teclado matricial
+   if( !gpioRead( TEC1 ) ){
+	   if (state==0)
+		   state=1; //Funcionalidad de ENTER y BACKSPACE
+	   else
+		   state=0; //Funcionalidad normal del teclado matricial
+   }
+
+   tecl_pres =leerTecladoMatricial();  // lectura de la tecla presionada
+   switch(state){
+
+   case 0:
+	   gpioWrite (LEDG, OFF);
+	   if(tecl_pres!=88){
+	   	   HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, keypadKeys[tecl_pres]);
+	      }
+	   break;
+   case 1:
+	   gpioWrite (LEDG, ON);
+	   if(tecl_pres!=88){
+	   	   	   HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, keypadKeysVol[tecl_pres]);
+	   	      }
+	   break;
+   }
+
+
+/*   if( !gpioRead( TEC1 ) ){
+      HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, 0x06); /* 'c' */
+/*   }
+   else if( !gpioRead( TEC2 ) ){
+      HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, 0x0C); /* 'i' */
+/*   }
+   else if( !gpioRead( TEC3 ) ){
+      HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, 0x04); /* 'a' */
+/*   }
+   else if( !gpioRead( TEC4 ) ){
+      HID_KEYBOARD_REPORT_SET_KEY_PRESS(g_keyBoard.report, 0x28); /* 'ENTER' */
+//   }
+
+}
+
+/* HID Get Report Request Callback. Called automatically on HID Get Report Request */
+static ErrorCode_t Keyboard_GetReport( USBD_HANDLE_T hHid,
+                                       USB_SETUP_PACKET *pSetup,
+                                       uint8_t * *pBuffer,
+                                       uint16_t *plength ){
+
+	/* ReportID = SetupPacket.wValue.WB.L; */
+	switch (pSetup->wValue.WB.H) {
+
+      case HID_REPORT_INPUT:
+         Keyboard_UpdateReport();
+         memcpy(*pBuffer, &g_keyBoard.report[0], KEYBOARD_REPORT_SIZE);
+         *plength = KEYBOARD_REPORT_SIZE;
+      break;
+
+      case HID_REPORT_OUTPUT:				/* Not Supported */
+      case HID_REPORT_FEATURE:			/* Not Supported */
+
+         return ERR_USBD_STALL;
+	}
+
+	return LPC_OK;
+}
+
+/* HID Set Report Request Callback. Called automatically on HID Set Report Request */
+static ErrorCode_t Keyboard_SetReport( USBD_HANDLE_T hHid,
+                                       USB_SETUP_PACKET *pSetup,
+                                       uint8_t * *pBuffer,
+                                       uint16_t length){
+
+   /* we will reuse standard EP0Buf */
+   if (length == 0) {
+      return LPC_OK;
+   }
+
+   /* ReportID = SetupPacket.wValue.WB.L; */
+   switch (pSetup->wValue.WB.H){
+
+      case HID_REPORT_OUTPUT:
+         /*  If the USB host tells us to turn on the NUM LOCK LED,
+          *  then turn on LED#2.
+          */
+         if (**pBuffer & 0x01) {
+            gpioWrite( LEDB, ON );
+         }
+         else {
+            gpioWrite( LEDB, OFF);
+         }
+      break;
+
+      case HID_REPORT_INPUT:				/* Not Supported */
+      case HID_REPORT_FEATURE:			/* Not Supported */
+
+         return ERR_USBD_STALL;
+   }
+
+   return LPC_OK;
+}
+
+/* HID interrupt IN endpoint handler */
+static ErrorCode_t Keyboard_EpIN_Hdlr( USBD_HANDLE_T hUsb,
+                                       void *data,
+                                       uint32_t event ){
+   switch (event) {
+      case USB_EVT_IN:
+         g_keyBoard.tx_busy = 0;
+         break;
+   }
+   return LPC_OK;
+}
+
+/*****************************************************************************
+ * Public functions
+ ****************************************************************************/
+
+/* HID keyboard init routine */
+ErrorCode_t Keyboard_init(USBD_HANDLE_T hUsb,
+						  USB_INTERFACE_DESCRIPTOR *pIntfDesc,
+						  uint32_t *mem_base,
+						  uint32_t *mem_size){
+
+   USBD_HID_INIT_PARAM_T hid_param;
+   USB_HID_REPORT_T reports_data[1];
+   ErrorCode_t ret = LPC_OK;
+
+   /* Do a quick check of if the interface descriptor passed is the right one. */
+   if( (pIntfDesc == 0) || (pIntfDesc->bInterfaceClass
+       != USB_DEVICE_CLASS_HUMAN_INTERFACE)) {
+      return ERR_FAILED;
+   }
+
+   /* Init HID params */
+   memset((void *) &hid_param, 0, sizeof(USBD_HID_INIT_PARAM_T));
+   hid_param.max_reports = 1;
+   hid_param.mem_base = *mem_base;
+   hid_param.mem_size = *mem_size;
+   hid_param.intf_desc = (uint8_t *) pIntfDesc;
+
+   /* user defined functions */
+   hid_param.HID_GetReport = Keyboard_GetReport;
+   hid_param.HID_SetReport = Keyboard_SetReport;
+   hid_param.HID_EpIn_Hdlr  = Keyboard_EpIN_Hdlr;
+
+   /* Init reports_data */
+   reports_data[0].len = Keyboard_ReportDescSize;
+   reports_data[0].idle_time = 0;
+   reports_data[0].desc = (uint8_t *) &Keyboard_ReportDescriptor[0];
+   hid_param.report_data  = reports_data;
+
+   ret = USBD_API->hid->init(hUsb, &hid_param);
+
+   /* update memory variables */
+   *mem_base = hid_param.mem_base;
+   *mem_size = hid_param.mem_size;
+
+   /* store stack handle for later use. */
+   g_keyBoard.hUsb = hUsb;
+   g_keyBoard.tx_busy = 0;
+
+   return ret;
+}
+
+/* Keyboard tasks */
+void Keyboard_Tasks(void)
+{
+	/* check device is configured before sending report. */
+	if ( USB_IsConfigured(g_keyBoard.hUsb)) {
+
+		/* send report data */
+		if (g_keyBoard.tx_busy == 0) {
+			g_keyBoard.tx_busy = 1;
+
+			/* update report based on board state */
+			Keyboard_UpdateReport();
+			USBD_API->hw->WriteEP( g_keyBoard.hUsb,
+			                       HID_EP_IN,
+			                       &g_keyBoard.report[0],
+			                       KEYBOARD_REPORT_SIZE );
+		}
+	}
+	else {
+		/* reset busy flag if we get disconnected. */
+		g_keyBoard.tx_busy = 0;
+	}
+
+}

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/keypad4x4.c
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/keypad4x4.c
@@ -1,0 +1,110 @@
+#include "sapi.h"
+// Guarda la ultima tecla apretada
+uint16_t key = 0;
+// Pines conectados a las Filas --> Salidas (MODO = OUTPUT)
+uint8_t keypadRowPins[4] = {
+   RS232_TXD, // Row 0
+   CAN_RD,    // R1
+   CAN_TD,    // R2
+   T_COL1     // R3
+};
+// Pines conectados a las Columnas --> Entradas con pull-up (MODO = INPUT_PULLUP)
+uint8_t keypadColPins[4] = {
+   T_FIL0,    // Column 0
+   T_FIL3,    // C1
+   T_FIL2,    // C2
+   T_COL0     // C3
+};
+// Vector para mostrar tecla presionada por UART
+uint16_t asciiKeypadKeys[16] = {
+                                '1', '2', '3', 'A',
+                                '4', '5', '6', 'B',
+                                '7', '8', '9', 'C',
+                                '*', '0', '#', 'D'
+                               };
+                               
+// Vector para mostrar tecla presionada en el display 7 segmentos
+/*uint16_t keypadKeys[16] = {
+                               1,    2,    3, 0x0a,
+                               4,    5,    6, 0x0b,
+                               7,    8,    9, 0x0c,
+                            0x0e,    0, 0x0f, 0x0d
+                          };*/
+                          
+void configurarTecladoMatricial( void ){
+   
+   uint8_t i = 0;
+   
+   // Configure Rows as Outputs
+   for( i=0; i<4; i++ ){
+      gpioConfig( keypadRowPins[i], GPIO_OUTPUT );
+   }
+
+   // Configure Columns as Inputs with pull-up resistors enable
+   for( i=0; i<4; i++ ){
+      gpioConfig( keypadColPins[i], GPIO_INPUT_PULLUP );
+   }
+}
+
+
+/* Devuelve TRUE si hay alguna tecla presionada o FALSE (0) en caso contrario.
+ * Si hay tecla presionada guarda el valor en la variable key.
+ * El valor es un numero de indice entre 0 y 15 */
+uint16_t leerTecladoMatricial( void ){
+
+   bool_t retVal = FALSE;
+
+   uint16_t r = 0; // Rows
+   uint16_t c = 0; // Columns
+
+   // Poner todas las filas en estado BAJO
+   for( r=0; r<4; r++ ){
+	  gpioWrite( keypadRowPins[r], LOW );
+   }
+
+   // Chequear todas las columnas buscando si hay alguna tecla presionada
+   for( c=0; c<4; c++ ){
+
+      // Si leo un estado BAJO en una columna entonces puede haber una tecla presionada
+      if( !gpioRead( keypadColPins[c] ) ){
+
+         delay( 50 ); // Anti-rebotes de 50 ms
+
+         // Poner todas las filas en estado ALTO excepto la primera
+         for( r=1; r<4; r++ ){
+            gpioWrite( keypadRowPins[r], HIGH );
+         }
+
+         // Buscar que tecla esta presionada
+         for( r=0; r<4; r++ ){
+
+            // Poner la Fila[r-1] en estado ALTO y la Fila[r] en estado BAJO
+            if( r>0 ){ // Exceptua el indice negativo en el array
+               gpioWrite( keypadRowPins[r-1], HIGH );
+            }
+            gpioWrite( keypadRowPins[r], LOW );
+
+            // Chequear la Columna[c] en Fila[r] para buscar si la tecla esta presionada
+            // Si dicha tecla esta oresionada (en estado BAJO) entonces retorna
+            // graba la tecla en key y retorna TRUE
+            if( !gpioRead( keypadColPins[c] ) ){
+               retVal = TRUE;
+               key = r * 4 + c;
+               /*
+                  Formula de las teclas de Teclado Matricial (Keypad)
+                  de 4 filas (rows) * 5 columnas (columns)
+
+                     c0 c1 c2 c3 c4
+                  r0  0  1  2  3  4
+                  r1  5  6  7  8  9   Si se presiona la tecla r[i] c[j]:
+                  r2 10 11 12 13 14   valor = (i) * cantidadDeColumnas + (j)
+                  r3 15 16 17 18 19
+               */
+               return key;
+            }
+         }
+
+      }
+   }
+   return 88;
+}

--- a/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/main.c
+++ b/Alumnos/Turno1/FabricioAvila/Entregables Nivel 2/sapi_usb_device_01_hid_keyboard_tecladoNum/src/main.c
@@ -1,0 +1,303 @@
+/*
+ * @brief This file contains USB HID Keyboard example using USB ROM Drivers.
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2013
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+
+/* Copyright 2016, Eric Pernia.
+ * All rights reserved.
+ *
+ * This file is part sAPI library for microcontrollers.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Date: 2016-11-06
+ */
+
+/*==================[inclusions]=============================================*/
+
+#include "sapi.h"         /* <= sAPI header */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "app_usbd_cfg.h"
+
+#include "hid_keyboard.h"
+
+#include "keypad4x4.h"
+/*==================[macros and definitions]=================================*/
+
+/*==================[internal data declaration]==============================*/
+
+/*==================[internal functions declaration]=========================*/
+
+/*==================[internal data definition]===============================*/
+
+/*==================[external data definition]===============================*/
+
+/*==================[internal functions definition]==========================*/
+
+/*==================[external functions definition]==========================*/
+
+
+/*****************************************************************************
+ * Private types/enumerations/variables
+ ****************************************************************************/
+static USBD_HANDLE_T g_hUsb;
+
+/* Endpoint 0 patch that prevents nested NAK event processing */
+static uint32_t g_ep0RxBusy = 0;/* flag indicating whether EP0 OUT/RX buffer is busy. */
+static USB_EP_HANDLER_T g_Ep0BaseHdlr; /* variable to store the pointer to base EP0 handler */
+
+/*****************************************************************************
+ * Public types/enumerations/variables
+ ****************************************************************************/
+const USBD_API_T *g_pUsbApi;
+
+/*****************************************************************************
+ * Private functions
+ ****************************************************************************/
+
+/* EP0_patch part of WORKAROUND for artf45032. */
+ErrorCode_t EP0_patch(USBD_HANDLE_T hUsb, void *data, uint32_t event)
+{
+   switch (event) {
+   case USB_EVT_OUT_NAK:
+      if (g_ep0RxBusy) {
+         /* we already queued the buffer so ignore this NAK event. */
+         return LPC_OK;
+      }
+      else {
+         /* Mark EP0_RX buffer as busy and allow base handler to queue the buffer. */
+         g_ep0RxBusy = 1;
+      }
+      break;
+
+   case USB_EVT_SETUP:  /* reset the flag when new setup sequence starts */
+   case USB_EVT_OUT:
+      /* we received the packet so clear the flag. */
+      g_ep0RxBusy = 0;
+      break;
+   }
+   return g_Ep0BaseHdlr(hUsb, data, event);
+}
+
+
+/*****************************************************************************
+ * Public functions
+ ****************************************************************************/
+
+/**
+ * @brief   Handle interrupt from USB
+ * @return  Nothing
+ */
+void USB_IRQHandler(void){
+   USBD_API->hw->ISR(g_hUsb);
+}
+
+
+/* Find the address of interface descriptor for given class type. */
+USB_INTERFACE_DESCRIPTOR *find_IntfDesc(const uint8_t *pDesc, uint32_t intfClass)
+{
+   USB_COMMON_DESCRIPTOR *pD;
+   USB_INTERFACE_DESCRIPTOR *pIntfDesc = 0;
+   uint32_t next_desc_adr;
+
+   pD = (USB_COMMON_DESCRIPTOR *) pDesc;
+   next_desc_adr = (uint32_t) pDesc;
+
+   while (pD->bLength) {
+      /* is it interface descriptor */
+      if (pD->bDescriptorType == USB_INTERFACE_DESCRIPTOR_TYPE) {
+
+         pIntfDesc = (USB_INTERFACE_DESCRIPTOR *) pD;
+         /* did we find the right interface descriptor */
+         if (pIntfDesc->bInterfaceClass == intfClass) {
+            break;
+         }
+      }
+      pIntfDesc = 0;
+      next_desc_adr = (uint32_t) pD + pD->bLength;
+      pD = (USB_COMMON_DESCRIPTOR *) next_desc_adr;
+   }
+
+   return pIntfDesc;
+}
+
+
+/**
+ * @brief   Configuration routine for USBD UCOM example
+ * maxNumEP max number of endpoints supported by the USB device
+ *          controller instance (specified by \em usb_reg_base field)
+ *          to which this instance of stack is attached.
+ */
+void usbDeviceConfig( uint8_t maxNumEP, int32_t usbPriority ){
+
+   USBD_API_INIT_PARAM_T usb_param;
+   USB_CORE_DESCS_T desc;
+   ErrorCode_t ret = LPC_OK;
+   USB_CORE_CTRL_T *pCtrl;
+
+   /* enable clocks and pinmux */
+   USB_init_pin_clk();
+
+   /* Init USB API structure */
+   g_pUsbApi = (const USBD_API_T *) LPC_ROM_API->usbdApiBase;
+
+   /* initialize call back structures */
+   memset((void *) &usb_param, 0, sizeof(USBD_API_INIT_PARAM_T));
+   usb_param.usb_reg_base = LPC_USB_BASE;
+   usb_param.mem_base = USB_STACK_MEM_BASE;
+   usb_param.mem_size = USB_STACK_MEM_SIZE;
+
+   usb_param.max_num_ep = maxNumEP; // @Eric - En keyboard tiene 2
+
+   /* Set the USB descriptors */
+   desc.device_desc = (uint8_t *) USB_DeviceDescriptor;
+   desc.string_desc = (uint8_t *) USB_StringDescriptor;
+
+   #ifdef USE_USB0
+      desc.high_speed_desc = USB_HsConfigDescriptor;
+      desc.full_speed_desc = USB_FsConfigDescriptor;
+      desc.device_qualifier = (uint8_t *) USB_DeviceQualifier;
+   #else
+      /* Note, to pass USBCV test full-speed only devices should have both
+       * descriptor arrays point to same location and device_qualifier set
+       * to 0.
+       */
+      desc.high_speed_desc = USB_FsConfigDescriptor;
+      desc.full_speed_desc = USB_FsConfigDescriptor;
+      desc.device_qualifier = 0;
+   #endif
+
+   /* USB Initialization */
+   ret = USBD_API->hw->Init(&g_hUsb, &desc, &usb_param);
+
+   if (ret == LPC_OK) {
+
+      /* WORKAROUND for artf45032 ROM driver BUG:
+          Due to a race condition there is the chance that a second NAK event will
+          occur before the default endpoint0 handler has completed its preparation
+          of the DMA engine for the first NAK event. This can cause certain fields
+          in the DMA descriptors to be in an invalid state when the USB controller
+          reads them, thereby causing a hang.
+       */
+      pCtrl = (USB_CORE_CTRL_T *) g_hUsb; /* convert the handle to control structure */
+      g_Ep0BaseHdlr = pCtrl->ep_event_hdlr[0];/* retrieve the default EP0_OUT handler */
+      pCtrl->ep_event_hdlr[0] = EP0_patch;/* set our patch routine as EP0_OUT handler */
+
+
+      ret = Keyboard_init( g_hUsb,
+                           (USB_INTERFACE_DESCRIPTOR *) &USB_FsConfigDescriptor[sizeof(USB_CONFIGURATION_DESCRIPTOR)],
+                           &usb_param.mem_base, &usb_param.mem_size );
+
+      if (ret == LPC_OK) {
+         /* Make sure USB and UART IRQ priorities are same for this example */
+         if( usbPriority >=0 ){
+            NVIC_SetPriority( LPC_USB_IRQ, (uint32_t)usbPriority ); // @Eric - En el de keyboard no modifica la prioridad de la IRQ
+         }
+          /*  enable USB interrupts */
+         NVIC_EnableIRQ( LPC_USB_IRQ );
+         /* now connect */
+         USBD_API->hw->Connect( g_hUsb, 1 );
+      }
+   }
+
+}
+
+
+
+/* FUNCION PRINCIPAL, PUNTO DE ENTRADA AL PROGRAMA LUEGO DE RESET. */
+int main(void){
+
+   /* ------------- INICIALIZACIONES ------------- */
+
+   /* Inicializar la placa */
+   boardConfig();
+   configurarTecladoMatricial(); // Configurar teclado matricial
+   bool_t ledStatus = OFF;
+   delay_t ledDelay;
+
+   delayConfig( &ledDelay, 500 );
+
+
+   // Configuration routine for USBD UCOM example
+   usbDeviceConfig( 2, -1 );
+
+   /* ------------- REPETIR POR SIEMPRE ------------- */
+   while(1) {
+
+      /* Do Keyboard tasks */
+      Keyboard_Tasks();
+
+      if( delayRead( &ledDelay ) ){
+         if( ledStatus ){
+            ledStatus = OFF;
+         } else{
+            ledStatus = ON;
+         }
+      }
+
+      /* Sleep until next IRQ happens */
+      __WFI();
+   }
+
+   /* NO DEBE LLEGAR NUNCA AQUI, debido a que a este programa no es llamado
+      por ningun S.O. */
+   return 0 ;
+}
+
+/*==================[end of file]============================================*/


### PR DESCRIPTION
HID: añadidas las funciones de teclado matricial+ENTER+BACKSPACE,
Se tienen dos estados: state 0, con la funcional del teclado matricial
                                     state 1, "1" es ENTER y "2" BACKSPACE, adicionalmente se enciende el LEDG
Se selecciona entre ambos estados con TEC1.
La mayoría de las modificaciones las hice en el archivo hid_keyboard.c
 